### PR TITLE
Fix end line

### DIFF
--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -234,10 +234,7 @@ struct formatter<spdlog::details::dump_info<T>, char>
     template<typename It>
     void put_newline(It inserter, std::size_t pos)
     {
-#ifdef _WIN32
-        *inserter++ = '\r';
-#endif
-        *inserter++ = '\n';
+       *inserter++ = '\n';
 
         if (put_positions)
         {


### PR DESCRIPTION
run on Windows https://godbolt.org/z/PYo3Ys8fa an look at  generated .TXT  
default `\r\r\n`  insted of `\r\n`  
please apply patch 